### PR TITLE
Select2Asset rendering files when part of combined asset bugfix

### DIFF
--- a/Select2Asset.php
+++ b/Select2Asset.php
@@ -3,7 +3,7 @@
 /**
  * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2014
  * @package yii2-widgets
- * @subpackage yii2-widget-select2 
+ * @subpackage yii2-widget-select2
  * @version 1.0.0
  */
 
@@ -23,6 +23,12 @@ class Select2Asset extends \kartik\base\AssetBundle
     public function init()
     {
         $this->setSourcePath(__DIR__ . '/lib');
+
+        // exit if using as part of combined asset
+        if (in_array('all', $this->depends)) {
+    		return;
+    	}
+
         $this->setupAssets('css', ['select2', 'select2-kv']);
         $this->setupAssets('js', ['select2', 'select2-kv']);
         parent::init();


### PR DESCRIPTION
This bugfix solves the issue of using `Select2Asset` as part of combined asset generated using `php yii asset` command. The asset would still renders it's css and js files to html, and since they are already included in the combined asset, this is not needed.