### PR TITLE
Fix bug on embedAddon function

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -174,7 +174,7 @@ class Select2 extends \kartik\base\InputWidget
      */
     protected function embedAddon($input)
     {
-        if (empty($this->addon)) {
+        if (!isset($this->size) && empty($this->addon)) {
             return $input;
         }
         $group = ArrayHelper::getValue($this->addon, 'groupOptions', []);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1927032/9905294/d6b47610-5c8c-11e5-8629-ac44cfbba03a.png)

This bug affects the container creation <div class = "input-group input-group-md"> </div> around select2 plugin structure with position:relative css option. In this case, select 100% equals the width of the window.

![image](https://cloud.githubusercontent.com/assets/1927032/9905378/511d4382-5c8d-11e5-8cd6-77e72c02e12d.png)
