### PR TITLE
Fix data transmission to launch the plugin in the plugin

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -192,7 +192,7 @@ class Select2 extends InputWidget
                         if ($this->model instanceof Model) {
                             $val = call_user_func($this->initValueText, $this->model);
                         } else {
-                            $val = call_user_func($this->initValueText);
+                            $val = call_user_func($this->initValueText, null);
                         }
                     } else {
                         $val = $this->initValueText;

--- a/Select2.php
+++ b/Select2.php
@@ -187,7 +187,19 @@ class Select2 extends InputWidget
                 $this->data = [];
             } else {
                 $key = isset($this->value) ? $this->value : ($multiple ? [] : '');
-                $val = isset($this->initValueText) ? $this->initValueText : $key;
+                if (isset($this->initValueText)) {
+                    if ($this->initValueText instanceof \Closure) {
+                        if ($this->model instanceof Model) {
+                            $val = call_user_func($this->initValueText, $this->model);
+                        } else {
+                            $val = call_user_func($this->initValueText);
+                        }
+                    } else {
+                        $val = $this->initValueText;
+                    }
+                } else {
+                    $val = $key;
+                }
                 $this->data = $multiple ? array_combine($key, $val) : [$key => $val];
             }
         }


### PR DESCRIPTION
if using plugin in other plugin, when the ajax request, it can not pass parameters to the model.
for example:

```
MultipleInput::widget([
    'name' => 'prices',
    'data' => $model->prices,
    'columns' => [
        [
            'name' => 'city_id',
            'value' => function ($item) {
                return $item && $item->city ? $item->city->name : '';
            },
            'title' => 'Город',
            'type' => Select2::className(),
            'options' => [
                'initValueText' => function ($item) {
                    /** @var ActiveRecord $item */
                    return $item && $item->city ? $item->city->name : '';
                },
                'pluginOptions' => [
                    'ajax' => [
                        'url' => Url::to(['city/ajax']),
                        'dataType' => 'json',
                        'data' => new \yii\web\JsExpression('function(params) { return {q:params.term}; }')
                    ]
                ]
            ]
        ]
    ]
])
```