### PR TITLE
'hideSearch' => true does not work

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -178,6 +178,9 @@ class Select2 extends InputWidget
         if (!empty($this->addon) || empty($this->pluginOptions['width'])) {
             $this->pluginOptions['width'] = '100%';
         }
+        if( isset($this->options['hideSearch'])) {
+            $this->hideSearch = $this->options['hideSearch'];
+        }
         if ($this->hideSearch) {
             $this->pluginOptions['minimumResultsForSearch'] = new JsExpression('Infinity');
         }


### PR DESCRIPTION
<?= $form->field($model, 'role')->widget(Select2::classname(), [
        'data' => User::getDataList(),
        'options' => ['hideSearch' => true,],
    ]);
?>

In the above code, search box can not be hidden.