### PR TITLE
Update line 4053

### DIFF
--- a/assets/js/select2.full.js
+++ b/assets/js/select2.full.js
@@ -4050,7 +4050,7 @@ S2.define('select2/dropdown/attachBody',[
   '../utils'
 ], function ($, Utils) {
   function AttachBody (decorated, $element, options) {
-    this.$dropdownParent = options.get('dropdownParent') || $(document.body);
+    this.$dropdownParent = $(options.get('dropdownParent')) || $(document.body);
 
     decorated.call(this, $element, options);
   }


### PR DESCRIPTION
Update line 4053 to utilize option dropdownParent (tag or id or class)

From:  this.$dropdownParent = options.get('dropdownParent') || $(document.body);
To: this.$dropdownParent = $(options.get('dropdownParent')) || $(document.body);