### PR TITLE
Update Select2.php

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -382,7 +382,7 @@ class Select2 extends InputWidget
     {
         $id = $this->options['id'];
         $this->registerAssetBundle();
-        $isMultiple = $this->options['multiple'];
+        $isMultiple = isset($this->options['multiple']) && $this->options['multiple'];
         $options = Json::encode([
             'themeCss' => ".select2-container--{$this->theme}",
             'sizeCss' => empty($this->addon) && $this->size !== self::MEDIUM ? 'input-' . $this->size : '',


### PR DESCRIPTION
$this->options['multiple'] may not be set, in which case a PHP warning is thrown. This fix checks if `multiple` isset first.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation