### PR TITLE
[fix] allow theme to be overriden by pluginOptions

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -194,7 +194,7 @@ class Select2 extends InputWidget
     public function renderWidget()
     {
         $this->initI18N(__DIR__);
-        $this->pluginOptions['theme'] = $this->theme;
+        $this->theme = !empty($this->pluginOptions['theme']) ? $this->pluginOptions['theme'] : $this->theme;
         $multiple = ArrayHelper::getValue($this->pluginOptions, 'multiple', false);
         unset($this->pluginOptions['multiple']);
         $multiple = ArrayHelper::getValue($this->options, 'multiple', $multiple);


### PR DESCRIPTION
## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- inverted the theme assignment in the renderWidget function to enable overriding it from pluginOptions
