### PR TITLE
FIxed bug in ajax multiple select 

### DIFF
--- a/Select2.php
+++ b/Select2.php
@@ -216,7 +216,7 @@ class Select2 extends InputWidget
                     $key = isset($this->value) ? $this->value : '';
                 }
                 $val = isset($this->initValueText) ? $this->initValueText : $key;
-                $this->data = $multiple ? array_combine($key, $val) : [$key => $val];
+                $this->data = $multiple ?  array_combine((array)$key, (array)$val) : [$key => $val];
             }
         }
         Html::addCssClass($this->options, 'form-control');


### PR DESCRIPTION
Array Format

## Scope
This pull request includes a
- [ ] Bug fix

## Changes
The following changes were made

>  array_combine($key, $val)

 changed to

>  array_combine((array)$key, (array)$val)

## Related Issues

Its returning result as
`Array
(
    [aaaaa] => aaaaa,
    [qq] => qq
)
`
instead of  
`Array
(
    [1] => aaaaa,
    [2] => qq
)
`