### PR TITLE
Change display from none to hidden

### DIFF
--- a/src/Select2.php
+++ b/src/Select2.php
@@ -361,7 +361,7 @@ class Select2 extends InputWidget
     {
         if ($this->pluginLoading) {
             $this->_loadIndicator = '<div class="kv-plugin-loading loading-' . $this->options['id'] . '">&nbsp;</div>';
-            Html::addCssStyle($this->options, 'display:none');
+            Html::addCssStyle($this->options, 'display:hidden');
         }
         Html::addCssClass($this->options, 'form-control');
         $input = $this->getInput('dropDownList', true);


### PR DESCRIPTION
Change display from none to hidden in order to support validator without using ActiveForm and model.

        <?php
            echo Select2::widget([
                'id' => 'myform-id',
                'name' => 'MyForm[id]',
                'value' => $model->cell,
                'options' => ['placeholder' => 'E.g.: C6865E', 'autofocus' => false, 'class' => 'required'],
                'data' => $arrPair,
                'pluginOptions' => [
                    'allowClear' => true,
                    'tag' => true,
                ],
            ]);
        ?>

```
<script>
$(document).ready(function() {
    var myformValid = myform.validate({
        errorPlacement: function (error, element) {
            if (element.next().hasClass("select2")) {
                error.insertAfter(element.next());
            } else {
                error.insertAfter(element);
            }
        },
    });
});
</script>
```

## Scope
This pull request includes a

- [ ] Bug fix
- [*] New feature
- [ ] Translation

## Changes
The following changes were made

- Html::addCssStyle($this->options, 'display:hidden');
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.