### PR TITLE
Fix #289: if no options (data) are provided generate an empty optiong…

### DIFF
--- a/src/Select2.php
+++ b/src/Select2.php
@@ -227,16 +227,16 @@ class Select2 extends InputWidget
             $this->pluginOptions['minimumResultsForSearch'] = new JsExpression('Infinity');
         }
         $this->initPlaceholder();
-        if (!isset($this->data)) {
-            if (!isset($this->value) && !isset($this->initValueText)) {
-                $this->data = [];
+        if (!$this->data) {
+            if (!$this->value && !$this->initValueText) {
+                $this->data = ['' => ''];
             } else {
                 if ($multiple) {
-                    $key = isset($this->value) && is_array($this->value) ? $this->value : [];
+                    $key = $this->value && is_array($this->value) ? $this->value : [];
                 } else {
-                    $key = isset($this->value) ? $this->value : '';
+                    $key = $this->value ? $this->value : '';
                 }
-                $val = isset($this->initValueText) ? $this->initValueText : $key;
+                $val = $this->initValueText ? $this->initValueText : $key;
                 $this->data = $multiple ? array_combine((array)$key, (array)$val) : [$key => $val];
             }
         }


### PR DESCRIPTION
…roup.

Refer to https://w3c.github.io/html-reference/select.html

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
- remove isset(): the propertys are setted by class-definition. We want to check if !null. 
- force a empty string as optiongroup if no data was set.


## Related Issues
If this is related to an existing ticket, include a link to it as well.