### PR TITLE
Fix #350: "Select All" / "Unselect All" not shown when property hashVarLoadPosition is View::POS_READY (some options does not pass from PHP to JS)

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -6,6 +6,7 @@ Change Log: `yii2-widget-select2`
 **Date:** _under development_
 
 - (enh #348): Standardize Krajee theme for each BS version & other style enhancements.
+- (bug #350): Some options do not work when `hashVarLoadPosition` is `View::POS_READY`.
 
 ## Version 2.2.3
 

--- a/src/Select2.php
+++ b/src/Select2.php
@@ -457,7 +457,7 @@ class Select2 extends InputWidget
         $this->_s2OptionsVar = 's2options_'.hash('crc32', $options);
         $this->options['data-s2-options'] = $this->_s2OptionsVar;
         $view = $this->getView();
-        $view->registerJs("var {$this->_s2OptionsVar} = {$options};", $this->hashVarLoadPosition);
+        $view->registerJs("window.{$this->_s2OptionsVar} = {$options};", $this->hashVarLoadPosition);
         if ($this->maintainOrder) {
             $val = Json::encode(is_array($this->value) ? $this->value : [$this->value]);
             $view->registerJs("initS2Order('{$id}',{$val});");


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Fixed issue https://github.com/kartik-v/yii2-widget-select2/issues/350.
- Update CHANGE.md.

## Related Issues

https://github.com/kartik-v/yii2-widget-select2/issues/350